### PR TITLE
Fix panic on mismatched roles/messages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,10 @@ async fn send_message(
         .iter()
         .enumerate()
         .map(|(i, x)| ChatMessage {
-            role: all_roles[i].clone(),
+            role: all_roles
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| "user".to_string()),
             content: x.clone(),
         })
         .collect();
@@ -398,7 +401,10 @@ async fn regenerate_message(
         .iter()
         .enumerate()
         .map(|(i, x)| ChatMessage {
-            role: all_roles[i].clone(),
+            role: all_roles
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| "user".to_string()),
             content: x.clone(),
         })
         .collect();


### PR DESCRIPTION
## Summary
- handle mismatched message/role counts gracefully

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6840558e891c8329a9f87ccce14c45b4